### PR TITLE
Added support for multi-character emojis

### DIFF
--- a/emoji/search.py
+++ b/emoji/search.py
@@ -45,8 +45,9 @@ def search(emoji: str) -> Emoji:
     name: str
     try:
         heading = soup.find('article').find('h1').get_text()
-        symbol = heading[0]
-        name = heading[2:]
+        split_heading = heading.split()
+        symbol = split_heading[0]
+        name = ' '.join(split_heading[1:])
     except:
         symbol = ""
         name = ""


### PR DESCRIPTION
At the moment, the emoji symbol is extracted by taking the first character of the heading.

This works for most emojis, but not for multi-character emojis, such as [black-cat](https://emojipedia.org/black-cat/) or [eye-in-speech-bubble](https://emojipedia.org/eye-in-speech-bubble/) (which are made up of two emojis combined with a zero width joiner).

Therefore this PR extracts the emoji symbol by taking the first "word" of the heading, by splitting the heading by its spaces.

It then joins the spaces back up again to get the name.

By extracting the emoji this way, the library can support both single-character and multi-character emojis.

# Screenshots

**Before**
![image](https://user-images.githubusercontent.com/30006386/101122780-29372a80-35eb-11eb-8edc-96361ec2e51f.png)

**After**
![image](https://user-images.githubusercontent.com/30006386/101122846-5a175f80-35eb-11eb-9a96-b145f31721de.png)
